### PR TITLE
SB-47: hide 'done' button when in 'drag mode lite'

### DIFF
--- a/src/components/ChannelGrid.svelte
+++ b/src/components/ChannelGrid.svelte
@@ -343,7 +343,7 @@
 			</div>
 		{/each}
 	</section>
-	{#if editModeEnabled}
+	{#if editModeEnabled && !editModeInitializedByDrag}
 		<div class="flex flex-col items-center justify-center">
 			<div
 				on:click={handleEditModeToggle}


### PR DESCRIPTION
This fixes a bug that showed a confirmation button when a user just drags an app without entering the full edit mode.